### PR TITLE
Adding a Json container encapsulating the object value

### DIFF
--- a/src/main/scala/io/leonard/ClassMapping.scala
+++ b/src/main/scala/io/leonard/ClassMapping.scala
@@ -1,0 +1,8 @@
+package io.leonard
+
+import play.api.libs.json.Format
+
+case class Mapping[A](
+                       name: String,
+                       format: Format[A]
+                     )

--- a/src/main/scala/io/leonard/SerializationStrategy.scala
+++ b/src/main/scala/io/leonard/SerializationStrategy.scala
@@ -1,0 +1,81 @@
+package io.leonard
+
+import play.api.libs.json._
+
+/**
+  * A serializationStrategy is responsible of serialized JSON content organisation
+  */
+trait SerializationStrategy {
+  def reads[Supertype](js: JsValue, mapping: Map[Class[_], Mapping[Supertype]]): JsResult[Supertype]
+  def writes[Supertype, Subtype](o: Supertype, name: String, in: Format[Subtype]): JsValue
+}
+
+/**
+  * SubProperty strategy will format JSON like this
+  * {
+  *   "value": {
+  *     "prop1": "Example content"
+  *   },
+  *   "type": "Cat"
+  * }
+  *
+  * @param discriminatorProperty
+  * @param containerProperty
+  */
+class SubProperty(val discriminatorProperty: String, val containerProperty: String) extends SerializationStrategy {
+  override def reads[Supertype](js: JsValue, mapping: Map[Class[_], Mapping[Supertype]]): JsResult[Supertype] = {
+    val discriminator = (js \ discriminatorProperty).validate[String]
+    val content = (js \ containerProperty).validate[JsObject]
+    (discriminator, content) match {
+      case (JsSuccess(extractedName, _), JsSuccess(extractedContent, _)) =>
+        mapping.values
+          .find(_.name == extractedName)
+          .map(_.format)
+          .map(_.reads(extractedContent))
+          .getOrElse(JsError(s"Could not find deserialisation format for discriminator '$discriminatorProperty' in $js."))
+      case (JsError(_), JsSuccess(_, _)) => JsError(s"No valid discriminator property '$discriminatorProperty' found in $js.")
+      case (JsSuccess(_, _), JsError(_)) => JsError(s"No valid container property '$containerProperty' found in $js.")
+      case (JsError(_), JsError(_)) => JsError(s"No valid discriminator property '$discriminatorProperty' nor container property '$containerProperty' found in $js.")
+    }
+  }
+  def writes[Supertype, Subtype](o: Supertype, name: String, in: Format[Subtype]): JsValue = Json.obj(
+    containerProperty -> in.writes(o.asInstanceOf[Subtype]).as[JsObject],
+    discriminatorProperty -> JsString(name)
+  )
+}
+
+object SubProperty extends SubProperty("type", "value") {
+
+}
+
+/**
+  * MergedObject strategy will format JSON like this
+  * {
+  *   "prop1": "Example content",
+  *   "type": "Cat"
+  * }
+  *
+  * With "type" being the default discriminator merged with the serialized object properties
+  *
+  * @param discriminatorProperty
+  */
+class MergedObject(val discriminatorProperty: String) extends SerializationStrategy {
+  override def reads[Supertype](js: JsValue, mapping: Map[Class[_], Mapping[Supertype]]): JsResult[Supertype] = {
+    val name = (js \ discriminatorProperty).validate[String]
+    name match {
+      case JsSuccess(extractedName, _) =>
+        mapping.values
+          .find(_.name == extractedName)
+          .map(_.format)
+          .map(_.reads(js))
+          .getOrElse(JsError(s"Could not find deserialisation format for discriminator '$discriminatorProperty' in $js."))
+      case _ => JsError(s"No valid discriminator property '$discriminatorProperty' found in $js.")
+    }
+  }
+
+  override def writes[Supertype, Subtype](o: Supertype, name: String, in: Format[Subtype]): JsValue = {
+    in.writes(o.asInstanceOf[Subtype]).as[JsObject] + (discriminatorProperty -> JsString(name))
+  }
+}
+
+object MergedObject extends MergedObject("type")

--- a/src/test/scala/io/leonard/AnimalSpec.scala
+++ b/src/test/scala/io/leonard/AnimalSpec.scala
@@ -1,0 +1,12 @@
+package io.leonard
+
+object AnimalSpec {
+  sealed trait Animal
+  case class Dog(s: String) extends Animal
+  case class Cat(s: String) extends Animal
+  case object Nessy         extends Animal
+
+  val doggy = Dog("woof!")
+  val kitty = Cat("Meow!")
+
+}

--- a/src/test/scala/io/leonard/SubPropertySerializationStrategySpec.scala
+++ b/src/test/scala/io/leonard/SubPropertySerializationStrategySpec.scala
@@ -1,0 +1,106 @@
+package io.leonard
+
+import io.leonard.AnimalSpec._
+import io.leonard.TraitFormat.{caseObjectFormat, traitFormat}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json.Json.format
+import play.api.libs.json.{JsError, Json}
+
+class SubPropertySerializationStrategySpec extends FlatSpec with Matchers  {
+
+  "TraitFormat with SubProperty serialization strategy" should "serialise" in {
+
+    val animalFormat = traitFormat[Animal](serialisationStrategy = SubProperty) << format[Dog] << format[Cat]
+
+    val doggyJson = """{"value":{"s":"woof!"},"type":"Dog"}"""
+    animalFormat.writes(doggy).toString() should be(doggyJson)
+
+    val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
+    animal1 should be(doggy)
+
+    val kittyJson = """{"value":{"s":"Meow!"},"type":"Cat"}"""
+    animalFormat.writes(kitty).toString() should be(kittyJson)
+
+    val animal2: Animal = animalFormat.reads(Json.parse(kittyJson)).get
+    animal2 should be(kitty)
+  }
+
+  it should "serialise a case object" in {
+    val animalFormat = traitFormat[Animal](serialisationStrategy = SubProperty) << format[Dog] << format[Cat] << caseObjectFormat(Nessy)
+    val nessyJson    = """{"value":{},"type":"Nessy"}"""
+    animalFormat.writes(Nessy) should be(Json.parse(nessyJson))
+    animalFormat.reads(Json.parse(nessyJson)).get should be(Nessy)
+  }
+
+  it should "put discriminator in the JSON" in {
+    val animalFormat = traitFormat[Animal](new SubProperty("animalType", "value")) << format[Dog] << format[Cat]
+    val doggyJson    = """{"value":{"s":"woof!"},"animalType":"Dog"}"""
+    animalFormat.writes(doggy).toString() should be(doggyJson)
+
+    val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
+    animal1 should be(doggy)
+  }
+
+  it should "put discriminator and container name in the JSON" in {
+    val animalFormat = traitFormat[Animal](new SubProperty("animalType", "data")) << format[Dog] << format[Cat]
+    val doggyJson    = """{"data":{"s":"woof!"},"animalType":"Dog"}"""
+    animalFormat.writes(doggy).toString() should be(doggyJson)
+
+    val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
+    animal1 should be(doggy)
+  }
+
+  it should "return a JsError if the discriminator is not there" in {
+    val animalFormat = traitFormat[Animal](SubProperty) << format[Dog] << format[Cat]
+    val doggyJson    = """{"value":{"s":"woof!"}}"""
+    val jsResult     = animalFormat.reads(Json.parse(doggyJson))
+    jsResult should be(JsError(s"No valid discriminator property 'type' found in $doggyJson."))
+  }
+
+  it should "return a JsError if the discriminator is not a string" in {
+    val animalFormat = traitFormat[Animal](SubProperty) << format[Dog] << format[Cat]
+    val doggyJson    = """{"value":{"s":"woof!"},"animalType":{"type":"Dog"}}"""
+    val jsResult     = animalFormat.reads(Json.parse(doggyJson))
+    jsResult should be(JsError(s"No valid discriminator property 'type' found in $doggyJson."))
+  }
+
+  it should "return a JsError if the container is missing" in {
+    val animalFormat = traitFormat[Animal](SubProperty) << format[Dog] << format[Cat]
+    val doggyJson    = """{"type":"Dog"}"""
+    val jsResult     = animalFormat.reads(Json.parse(doggyJson))
+    jsResult should be(JsError(s"No valid container property 'value' found in $doggyJson."))
+  }
+
+  it should "return a JsError if the container is not an object" in {
+    val animalFormat = traitFormat[Animal](SubProperty) << format[Dog] << format[Cat]
+    val doggyJson    = """{"value":"woof!","type":"Dog"}"""
+    val jsResult     = animalFormat.reads(Json.parse(doggyJson))
+    jsResult should be(JsError(s"No valid container property 'value' found in $doggyJson."))
+  }
+
+  it should "return a JsError if the container and discriminator are missing" in {
+    val animalFormat = traitFormat[Animal](SubProperty) << format[Dog] << format[Cat]
+    val doggyJson    = """{"s":"woof!","ff":"R"}"""
+    val jsResult     = animalFormat.reads(Json.parse(doggyJson))
+    jsResult should be(JsError(s"No valid discriminator property 'type' nor container property 'value' found in $doggyJson."))
+  }
+
+  it should "custom name for case class format" in {
+    val animalFormat = traitFormat[Animal](SubProperty) << ("hound", format[Dog]) << ("pussy_cat", format[Cat])
+    val houndJson    = """{"value":{"s":"woof!"},"type":"hound"}"""
+    val jsResult     = animalFormat.reads(Json.parse(houndJson))
+    jsResult.get should be(doggy)
+
+    val pussyCatJson = """{"value":{"s":"Meow!"},"type":"pussy_cat"}"""
+    animalFormat.reads(Json.parse(pussyCatJson)).get should be(kitty)
+  }
+
+  it should "write and read custom name for case object format" in {
+    val animalFormat = traitFormat[Animal](SubProperty) << ("hound", format[Dog]) << ("pussy_cat", format[Cat]) << ("sea_monster", caseObjectFormat(Nessy))
+    val nessyJson    = """{"value":{},"type":"sea_monster"}"""
+    val jsResult     = animalFormat.reads(Json.parse(nessyJson))
+    jsResult.get should be(Nessy)
+
+    animalFormat.writes(Nessy).toString() should be(nessyJson)
+  }
+}

--- a/src/test/scala/io/leonard/TraitFormatSpec.scala
+++ b/src/test/scala/io/leonard/TraitFormatSpec.scala
@@ -1,31 +1,24 @@
 package io.leonard
 
-import io.leonard.TraitFormat.{traitFormat, caseObjectFormat}
+import io.leonard.AnimalSpec._
+import io.leonard.TraitFormat.{caseObjectFormat, traitFormat}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.Json.format
 import play.api.libs.json._
 
-class TraitFormatSpec extends FlatSpec with Matchers {
-
-  sealed trait Animal
-  case class Dog(s: String) extends Animal
-  case class Cat(s: String) extends Animal
-  case object Nessy         extends Animal
-
-  val doggy = Dog("woof!")
-  val kitty = Cat("Meow!")
+class TraitFormatSpec extends FlatSpec with Matchers  {
 
   "TraitFormat" should "serialise" in {
 
     val animalFormat = traitFormat[Animal] << format[Dog] << format[Cat]
 
-    val doggyJson = """{"value":{"s":"woof!"},"name":"Dog"}"""
+    val doggyJson = """{"s":"woof!","type":"Dog"}"""
     animalFormat.writes(doggy).toString() should be(doggyJson)
 
     val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
     animal1 should be(doggy)
 
-    val kittyJson = """{"value":{"s":"Meow!"},"name":"Cat"}"""
+    val kittyJson = """{"s":"Meow!","type":"Cat"}"""
     animalFormat.writes(kitty).toString() should be(kittyJson)
 
     val animal2: Animal = animalFormat.reads(Json.parse(kittyJson)).get
@@ -34,23 +27,14 @@ class TraitFormatSpec extends FlatSpec with Matchers {
 
   it should "serialise a case object" in {
     val animalFormat = traitFormat[Animal] << format[Dog] << format[Cat] << caseObjectFormat(Nessy)
-    val nessyJson    = """{"value":{},"name":"Nessy"}"""
+    val nessyJson    = """{"type":"Nessy"}"""
     animalFormat.writes(Nessy) should be(Json.parse(nessyJson))
     animalFormat.reads(Json.parse(nessyJson)).get should be(Nessy)
   }
 
   it should "put discriminator in the JSON" in {
     val animalFormat = traitFormat[Animal]("animalType") << format[Dog] << format[Cat]
-    val doggyJson    = """{"value":{"s":"woof!"},"animalType":"Dog"}"""
-    animalFormat.writes(doggy).toString() should be(doggyJson)
-
-    val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
-    animal1 should be(doggy)
-  }
-
-  it should "put discriminator and container name in the JSON" in {
-    val animalFormat = traitFormat[Animal]("animalType", "data") << format[Dog] << format[Cat]
-    val doggyJson    = """{"data":{"s":"woof!"},"animalType":"Dog"}"""
+    val doggyJson    = """{"s":"woof!","animalType":"Dog"}"""
     animalFormat.writes(doggy).toString() should be(doggyJson)
 
     val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
@@ -66,13 +50,6 @@ class TraitFormatSpec extends FlatSpec with Matchers {
 
   it should "return a JsError if the discriminator is not a string" in {
     val animalFormat = traitFormat[Animal]("animalType") << format[Dog] << format[Cat]
-    val doggyJson    = """{"value":{"s":"woof!"},"animalType":{"type":"Dog"}}"""
-    val jsResult     = animalFormat.reads(Json.parse(doggyJson))
-    jsResult should be(JsError(s"No valid discriminator property 'animalType' found in $doggyJson."))
-  }
-
-  it should "return a JsError if the container is not there" in {
-    val animalFormat = traitFormat[Animal]("animalType", "data") << format[Dog] << format[Cat]
     val doggyJson    = """{"s":"woof!","animalType":{"type":"Dog"}}"""
     val jsResult     = animalFormat.reads(Json.parse(doggyJson))
     jsResult should be(JsError(s"No valid discriminator property 'animalType' found in $doggyJson."))
@@ -80,17 +57,17 @@ class TraitFormatSpec extends FlatSpec with Matchers {
 
   it should "custom name for case class format" in {
     val animalFormat = traitFormat[Animal] << ("hound", format[Dog]) << ("pussy_cat", format[Cat])
-    val houndJson    = """{"value":{"s":"woof!"},"name":"hound"}"""
+    val houndJson    = """{"s":"woof!","type":"hound"}"""
     val jsResult     = animalFormat.reads(Json.parse(houndJson))
     jsResult.get should be(doggy)
 
-    val pussyCatJson = """{"value":{"s":"Meow!"},"name":"pussy_cat"}"""
+    val pussyCatJson = """{"s":"Meow!","type":"pussy_cat"}"""
     animalFormat.reads(Json.parse(pussyCatJson)).get should be(kitty)
   }
 
   it should "write and read custom name for case object format" in {
     val animalFormat = traitFormat[Animal] << ("hound", format[Dog]) << ("pussy_cat", format[Cat]) << ("sea_monster", caseObjectFormat(Nessy))
-    val nessyJson    = """{"value":{},"name":"sea_monster"}"""
+    val nessyJson    = """{"type":"sea_monster"}"""
     val jsResult     = animalFormat.reads(Json.parse(nessyJson))
     jsResult.get should be(Nessy)
 

--- a/src/test/scala/io/leonard/TraitFormatSpec.scala
+++ b/src/test/scala/io/leonard/TraitFormatSpec.scala
@@ -19,13 +19,13 @@ class TraitFormatSpec extends FlatSpec with Matchers {
 
     val animalFormat = traitFormat[Animal] << format[Dog] << format[Cat]
 
-    val doggyJson = """{"s":"woof!","type":"Dog"}"""
+    val doggyJson = """{"value":{"s":"woof!"},"name":"Dog"}"""
     animalFormat.writes(doggy).toString() should be(doggyJson)
 
     val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
     animal1 should be(doggy)
 
-    val kittyJson = """{"s":"Meow!","type":"Cat"}"""
+    val kittyJson = """{"value":{"s":"Meow!"},"name":"Cat"}"""
     animalFormat.writes(kitty).toString() should be(kittyJson)
 
     val animal2: Animal = animalFormat.reads(Json.parse(kittyJson)).get
@@ -34,14 +34,23 @@ class TraitFormatSpec extends FlatSpec with Matchers {
 
   it should "serialise a case object" in {
     val animalFormat = traitFormat[Animal] << format[Dog] << format[Cat] << caseObjectFormat(Nessy)
-    val nessyJson    = """{"type":"Nessy"}"""
+    val nessyJson    = """{"value":{},"name":"Nessy"}"""
     animalFormat.writes(Nessy) should be(Json.parse(nessyJson))
     animalFormat.reads(Json.parse(nessyJson)).get should be(Nessy)
   }
 
   it should "put discriminator in the JSON" in {
     val animalFormat = traitFormat[Animal]("animalType") << format[Dog] << format[Cat]
-    val doggyJson    = """{"s":"woof!","animalType":"Dog"}"""
+    val doggyJson    = """{"value":{"s":"woof!"},"animalType":"Dog"}"""
+    animalFormat.writes(doggy).toString() should be(doggyJson)
+
+    val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
+    animal1 should be(doggy)
+  }
+
+  it should "put discriminator and container name in the JSON" in {
+    val animalFormat = traitFormat[Animal]("animalType", "data") << format[Dog] << format[Cat]
+    val doggyJson    = """{"data":{"s":"woof!"},"animalType":"Dog"}"""
     animalFormat.writes(doggy).toString() should be(doggyJson)
 
     val animal1: Animal = animalFormat.reads(Json.parse(doggyJson)).get
@@ -57,6 +66,13 @@ class TraitFormatSpec extends FlatSpec with Matchers {
 
   it should "return a JsError if the discriminator is not a string" in {
     val animalFormat = traitFormat[Animal]("animalType") << format[Dog] << format[Cat]
+    val doggyJson    = """{"value":{"s":"woof!"},"animalType":{"type":"Dog"}}"""
+    val jsResult     = animalFormat.reads(Json.parse(doggyJson))
+    jsResult should be(JsError(s"No valid discriminator property 'animalType' found in $doggyJson."))
+  }
+
+  it should "return a JsError if the container is not there" in {
+    val animalFormat = traitFormat[Animal]("animalType", "data") << format[Dog] << format[Cat]
     val doggyJson    = """{"s":"woof!","animalType":{"type":"Dog"}}"""
     val jsResult     = animalFormat.reads(Json.parse(doggyJson))
     jsResult should be(JsError(s"No valid discriminator property 'animalType' found in $doggyJson."))
@@ -64,17 +80,17 @@ class TraitFormatSpec extends FlatSpec with Matchers {
 
   it should "custom name for case class format" in {
     val animalFormat = traitFormat[Animal] << ("hound", format[Dog]) << ("pussy_cat", format[Cat])
-    val houndJson    = """{"s":"woof!","type":"hound"}"""
+    val houndJson    = """{"value":{"s":"woof!"},"name":"hound"}"""
     val jsResult     = animalFormat.reads(Json.parse(houndJson))
     jsResult.get should be(doggy)
 
-    val pussyCatJson = """{"s":"Meow!","type":"pussy_cat"}"""
+    val pussyCatJson = """{"value":{"s":"Meow!"},"name":"pussy_cat"}"""
     animalFormat.reads(Json.parse(pussyCatJson)).get should be(kitty)
   }
 
   it should "write and read custom name for case object format" in {
     val animalFormat = traitFormat[Animal] << ("hound", format[Dog]) << ("pussy_cat", format[Cat]) << ("sea_monster", caseObjectFormat(Nessy))
-    val nessyJson    = """{"type":"sea_monster"}"""
+    val nessyJson    = """{"value":{},"name":"sea_monster"}"""
     val jsResult     = animalFormat.reads(Json.parse(nessyJson))
     jsResult.get should be(Nessy)
 


### PR DESCRIPTION
Hello, 

I found your library useful for handling json serialization of case classes using traits, thanks for sharing it.
For backward-compatibility reasons I had to adjust the serialisation format and encapsulate the object value in a distinct js object.

You may not be interested in this at all, just wanted to let you know what we're doing here

