### PR TITLE
Update sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.0-RC3
+sbt.version = 1.0.2


### PR DESCRIPTION
Upgrading SBT version to avoid terminal breakage on certain condition, most probably something to do with iTerm2 or bash prompt that require escape caracters to work. 

See comments on https://github.com/sbt/sbt/issues/3482 