### PR TITLE
Support TraitFormat reuse

### DIFF
--- a/src/test/scala/io/leonard/AnimalSpec.scala
+++ b/src/test/scala/io/leonard/AnimalSpec.scala
@@ -2,8 +2,9 @@ package io.leonard
 
 object AnimalSpec {
   sealed trait Animal
-  case class Dog(s: String) extends Animal
-  case class Cat(s: String) extends Animal
+  sealed trait Mammal extends Animal
+  case class Dog(s: String) extends Mammal
+  case class Cat(s: String) extends Mammal
   case object Nessy         extends Animal
 
   val doggy = Dog("woof!")

--- a/src/test/scala/io/leonard/TraitFormatSpec.scala
+++ b/src/test/scala/io/leonard/TraitFormatSpec.scala
@@ -32,6 +32,15 @@ class TraitFormatSpec extends FlatSpec with Matchers  {
     animalFormat.reads(Json.parse(nessyJson)).get should be(Nessy)
   }
 
+  it should "serialise nested" in {
+    val mammalFormat = traitFormat[Mammal] << format[Dog] << format[Cat]
+    val animalFormat = traitFormat[Animal] << mammalFormat << caseObjectFormat(Nessy)
+
+    val doggyJson = """{"s":"woof!","type":"Dog"}"""
+    animalFormat.writes(doggy).toString() should be(doggyJson)
+
+  }
+
   it should "put discriminator in the JSON" in {
     val animalFormat = traitFormat[Animal]("animalType") << format[Dog] << format[Cat]
     val doggyJson    = """{"s":"woof!","animalType":"Dog"}"""


### PR DESCRIPTION
Support TraitFormat reuse like this

```scala
val mammalFormat = traitFormat[Mammal] << format[Dog] << format[Cat]
val animalFormat = traitFormat[Animal] << mammalFormat << caseObjectFormat(Nessy)
```